### PR TITLE
Create a valid PUT request when the entity identifier does not exactly match "ID" 

### DIFF
--- a/src/ExactOnline.Client.Sdk/Helpers/ApiConnection.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ApiConnection.cs
@@ -113,7 +113,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 			{
 				// Create correct endpoint
 				string endpoint = EndPoint;
-				if(keyName.Equals("ID")) endpoint += "(guid'" + guid + "')";
+				if(keyName.Contains("ID")) endpoint += "(guid'" + guid + "')";
 				else endpoint += "(" + guid + ")";
 
 				string response = _conn.DoPutRequest(endpoint, data);


### PR DESCRIPTION
When trying to update a SalesOrder, a 400 error was returned because of an invalid url for the PUT request. It appeared that the guid wasn't set with the guid prefix because the identifier has a name other than "ID" (OrderID). I noticed that within the creation of GET and DELETE requests the identifier name does not have to be exactly "ID" but has to contain "ID". Therefore I changed the generation of the PUT url to match the GET and DELETE requests.