### PR TITLE
Removed the check to see if instance is already created.

### DIFF
--- a/src/ExactOnline.Client.Sdk/Helpers/ControllerSingleton.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ControllerSingleton.cs
@@ -21,15 +21,13 @@ namespace ExactOnline.Client.Sdk.Helpers
 		/// </summary>
 		public static ControllerSingleton GetInstance(IApiConnector connector, string apiEndpoint)
 		{
-			if (_instance == null)
+			// This has to be created for each apiEndpoint. Otherwise it's not possible to use the SDK with multiple divisions.
+			_instance = new ControllerSingleton
 			{
-				_instance = new ControllerSingleton
-				{
-					_apiEndpoint = apiEndpoint,
-					_connector = connector,
-					_controllers = new Hashtable()
-				};
-			}
+				_apiEndpoint = apiEndpoint,
+				_connector = connector,
+				_controllers = new Hashtable()
+			};
 			return _instance;
 		}
 


### PR DESCRIPTION
If the SDK is used for multiple users in the same domain it won't work. the _apiEndpoint will be saved in the static _instance object and won't ever change.

Since the divisionID is stored in the _apiEndpoint, it's not possible to change the division after the first use of the SDK.

see issue #12 