### PR TITLE
Changed ControllerSingleton to support multiple connections

### DIFF
--- a/src/ConsoleApplication/Connector.cs
+++ b/src/ConsoleApplication/Connector.cs
@@ -8,8 +8,7 @@ namespace ConsoleApplication
 		private readonly string _clientId;
 		private readonly string _clientSecret;
 		private readonly Uri _callbackUrl;
-
-		private readonly static UserAuthorization Authorization = new UserAuthorization();
+		private readonly UserAuthorization _authorization;
 
 		public string EndPoint
 		{
@@ -24,13 +23,14 @@ namespace ConsoleApplication
 			_clientId = clientId;
 			_clientSecret = clientSecret;
 			_callbackUrl = callbackUrl;
+			_authorization = new UserAuthorization();
 		}
 
 		public string GetAccessToken()
 		{
-			UserAuthorizations.Authorize(Authorization, EndPoint, _clientId, _clientSecret, _callbackUrl);
+			UserAuthorizations.Authorize(_authorization, EndPoint, _clientId, _clientSecret, _callbackUrl);
 
-			return Authorization.AccessToken;
+			return _authorization.AccessToken;
 		}
 
 	}

--- a/src/ExactOnline.Client.OAuth/OAuthClient.cs
+++ b/src/ExactOnline.Client.OAuth/OAuthClient.cs
@@ -48,14 +48,9 @@ namespace ExactOnline.Client.OAuth
 			if (authorization.AccessToken == null || refreshFailed)
 			{
 				using (var loginDialog = new LoginForm(_redirectUri))
-				{
-					Uri url = RequestUserAuthorization(authorization);
-
-					var urlBuilder = new UriBuilder(url) {Query = url.Query.Substring(1)};
-					loginDialog.AuthorizationUri = urlBuilder.Uri;
-
+				{					
+					loginDialog.AuthorizationUri = GetAuthorizationUri(authorization);
 					loginDialog.ShowDialog();
-
 					ProcessUserAuthorization(loginDialog.AuthorizationUri, authorization);
 				}
 			}
@@ -78,6 +73,18 @@ namespace ExactOnline.Client.OAuth
 				return (timeToExpire.Minutes < 1);
 			}
 			return false;
+		}
+
+		private Uri GetAuthorizationUri(IAuthorizationState authorization)
+		{
+			var baseUri = RequestUserAuthorization(authorization);
+
+			var authorizationUriBuilder = new UriBuilder(baseUri)
+			{
+				Query = baseUri.Query.Substring(1) + "&force_login=1"
+			};
+
+			return authorizationUriBuilder.Uri;
 		}
 
 		#endregion

--- a/src/ExactOnline.Client.Sdk/Controllers/ExactOnlineClient.cs
+++ b/src/ExactOnline.Client.Sdk/Controllers/ExactOnlineClient.cs
@@ -13,7 +13,7 @@ namespace ExactOnline.Client.Sdk.Controllers
 	{
 		private readonly ApiConnector _apiConnector;
 		private readonly string _exactOnlineApiUrl;		// https://start.exactonline.nl/api/v1
-		private readonly ControllerSingleton _controllers;
+		private readonly ControllerList _controllers;
 
 		#region Constructors
 
@@ -35,7 +35,7 @@ namespace ExactOnline.Client.Sdk.Controllers
 			int currentDivision = (division > 0) ? division : GetDivision();
 			string serviceRoot = _exactOnlineApiUrl + currentDivision + "/";
 
-			_controllers = ControllerSingleton.GetInstance(_apiConnector, serviceRoot);
+			_controllers = new ControllerList(_apiConnector, serviceRoot);
 		}
 
 		/// <summary>

--- a/src/ExactOnline.Client.Sdk/Delegates/ManagerForEntitiesDelegate.cs
+++ b/src/ExactOnline.Client.Sdk/Delegates/ManagerForEntitiesDelegate.cs
@@ -4,7 +4,7 @@ using ExactOnline.Client.Sdk.Interfaces;
 namespace ExactOnline.Client.Sdk.Delegates
 {
 	/// <summary>
-	/// Delegate for low coupling between Controller and ControllerSingleton
+	/// Delegate for low coupling between Controller and ControllerList
 	/// Let the Controller find the associated controller for linked entity field without
 	/// knowing what other controllers exist
 	/// </summary>

--- a/src/ExactOnline.Client.Sdk/ExactOnline.Client.Sdk.csproj
+++ b/src/ExactOnline.Client.Sdk/ExactOnline.Client.Sdk.csproj
@@ -48,7 +48,7 @@
     <Compile Include="Helpers\ApiConnection.cs" />
     <Compile Include="Helpers\ApiConnector.cs" />
     <Compile Include="Helpers\ApiResponseCleaner.cs" />
-    <Compile Include="Helpers\ControllerSingleton.cs" />
+    <Compile Include="Helpers\ControllerList.cs" />
     <Compile Include="Helpers\ExactOnlineJsonConverter.cs" />
     <Compile Include="Controllers\ExactOnlineClient.cs" />
     <Compile Include="Helpers\EntityConverter.cs" />

--- a/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ControllerList.cs
@@ -6,50 +6,25 @@ using ExactOnline.Client.Sdk.Interfaces;
 namespace ExactOnline.Client.Sdk.Helpers
 {
 	/// <summary>
-	/// Manages instances of controllers to ensure that only one instance of a specific controller exists
+	/// Manages instances of controllers
 	/// </summary>
-	public class ControllerSingleton
+	public class ControllerList
 	{
-		static ControllerSingleton _instance;
+		private readonly IApiConnector _connector;
+		private readonly string _apiEndpoint;
+		private readonly Hashtable _controllers;
 
-		private IApiConnector _connector;
-		private string _apiEndpoint;
-		private Hashtable _controllers;
-
-		/// <summary>
-		/// Returns an instance of ControllerSingleton
-		/// </summary>
-		public static ControllerSingleton GetInstance(IApiConnector connector, string apiEndpoint)
+		public ControllerList(IApiConnector connector, string apiEndpoint)
 		{
-			if (_instance == null)
-			{
-				_instance = new ControllerSingleton
-				{
-					_apiEndpoint = apiEndpoint,
-					_connector = connector,
-					_controllers = new Hashtable()
-				};
-			}
-			return _instance;
-		}
-
-		/// <summary>
-		/// Returns an instance of ControllerSingleton. This method expects that the ControllerSingleton is already set.
-		/// </summary>
-		/// <returns></returns>
-		public static ControllerSingleton GetInstance()
-		{
-			if (_instance != null)
-			{
-				return _instance;
-			}
-			throw new Exception("Instance is not yet set. Use GetInstance(ApiConnector, ApiEndPoint");
+			_apiEndpoint = apiEndpoint;
+			_connector = connector;
+			_controllers = new Hashtable();
 		}
 
 		/// <summary>
 		/// Gets the name of the generic type
 		/// </summary>
-		private string GetTypename<T>()
+		private static string GetTypename<T>()
 		{
 			// Get entity name from type
 			var entity = typeof(T).ToString();
@@ -63,7 +38,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 		/// </summary>
 		public IEntityManager GetEntityManager(Type type)
 		{
-			var method = typeof(ControllerSingleton).GetMethod("GetController");
+			var method = typeof(ControllerList).GetMethod("GetController");
 			var genericMethod = method.MakeGenericMethod(new[] { type });
 			var controller = (IEntityManager)genericMethod.Invoke(this, null);
 			return controller;
@@ -76,7 +51,7 @@ namespace ExactOnline.Client.Sdk.Helpers
 		{
 			var typename = GetTypename<T>();
 			var returncontroller = (Controller<T>)_controllers[typename];
-			
+
 			// If not exists: create
 			if (returncontroller == null)
 			{
@@ -156,17 +131,9 @@ namespace ExactOnline.Client.Sdk.Helpers
 				};
 				_controllers.Add(typename, returncontroller);
 			}
-			
+
 			return returncontroller;
 		}
 
-		/// <summary>
-		/// Deletes instance of ControllerSingleton
-		/// </summary>
-		public static void Clean()
-		{
-			_instance = null;
-		}
-	
 	}
 }

--- a/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineJsonConverter.cs
+++ b/src/ExactOnline.Client.Sdk/Helpers/ExactOnlineJsonConverter.cs
@@ -121,16 +121,6 @@ namespace ExactOnline.Client.Sdk.Helpers
 
 		private EntityController GetEntityController(object entity)
 		{
-			//// Get associated controller of linked entity
-			//ControllerSingleton instance = ControllerSingleton.GetInstance();
-			//MethodInfo method = instance.GetType().GetMethod("GetController");
-			//MethodInfo genericMethod = method.MakeGenericMethod(new Type[] { entity.GetType() });
-			//IEntityManager entityManager = (IEntityManager)genericMethod.Invoke(instance, null);
-
-			//// Get the EntityController associated with the entity
-			//var entityIdentifier = entityManager.GetIdentifierValue(entity);
-			//var emanager = entityManager.GetEntityController(entityIdentifier);
-
 			var emanager = _entityControllerDelegate(entity);
 			return emanager;
 		}

--- a/src/ExactOnline.Client.Sdk/Interfaces/IEntityManager.cs
+++ b/src/ExactOnline.Client.Sdk/Interfaces/IEntityManager.cs
@@ -5,7 +5,7 @@ namespace ExactOnline.Client.Sdk.Interfaces
 {
 	/// <summary>
 	/// Interface for classes that manage a collection of (linked) entities
-	/// This interface is used by the ControllerSingleton class for 'GetEntityManager' method for fetching
+	/// This interface is used by the ControllerList class for 'GetEntityManager' method for fetching
 	/// the associated controller for a specific entity
 	/// </summary>
 	public interface IEntityManager

--- a/test/ExactOnline.Client.Sdk.UnitTests/ControllerTest.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/ControllerTest.cs
@@ -127,12 +127,11 @@ namespace ExactOnline.Client.Sdk.UnitTests
 		{
 			// Test if controller registrates linked entities
 			IApiConnector conn = new ApiConnectorControllerMock();
-			ControllerSingleton.Clean();
-			ControllerSingleton cs = ControllerSingleton.GetInstance(conn, string.Empty);
+			var controllerList = new ControllerList(conn, string.Empty);
 
-			var salesinvoicecontroller = (Controller<SalesInvoice>)cs.GetController<SalesInvoice>();
-			var invoicelines = (Controller<SalesInvoiceLine>)cs.GetController<SalesInvoiceLine>();
-			salesinvoicecontroller.GetManagerForEntity = cs.GetEntityManager;
+			var salesinvoicecontroller = (Controller<SalesInvoice>)controllerList.GetController<SalesInvoice>();
+			var invoicelines = (Controller<SalesInvoiceLine>)controllerList.GetController<SalesInvoiceLine>();
+			salesinvoicecontroller.GetManagerForEntity = controllerList.GetEntityManager;
 
 			// Verify if sales invoice lines are registrated entities
 			var invoice = salesinvoicecontroller.Get("")[0];

--- a/test/ExactOnline.Client.Sdk.UnitTests/EntityControllerTest.cs
+++ b/test/ExactOnline.Client.Sdk.UnitTests/EntityControllerTest.cs
@@ -17,12 +17,11 @@ namespace ExactOnline.Client.Sdk.UnitTests
 		[TestCategory("Unit Test")]
 		public void EntityController_Update_WithNewLinkedEntity_Succeeds()
 		{
-			ControllerSingleton.Clean();
 			var controllerMock = new ApiConnectionEntityControllerMock();
 			var apiConnectorMock = new ApiConnectorMock();
-			ControllerSingleton instance = ControllerSingleton.GetInstance(apiConnectorMock, "https://start.exactonline.nl/api/v1/");
+			var controllerList = new ControllerList(apiConnectorMock, "https://start.exactonline.nl/api/v1/");
 
-			var controller = (Controller<SalesInvoice>)instance.GetController<SalesInvoice>();
+			var controller = (Controller<SalesInvoice>)controllerList.GetController<SalesInvoice>();
 			var invoice = new SalesInvoice {Description = "New Description"};
 			var entityController = new EntityController(invoice, "ID", invoice.InvoiceID.ToString(), controllerMock, controller.GetEntityController);
 
@@ -42,16 +41,15 @@ namespace ExactOnline.Client.Sdk.UnitTests
 		[TestCategory("Unit Test")]
 		public void EntityController_Update_WithExistingLinkedEntity_Succeeds()
 		{
-			ControllerSingleton.Clean();
 			var controllerMock = new ApiConnectionEntityControllerMock();
 			var connector = new ApiConnectorMock();
-			ControllerSingleton instance = ControllerSingleton.GetInstance(connector, "https://start.exactonline.nl/api/v1/");
+			var controllerList = new ControllerList(connector, "https://start.exactonline.nl/api/v1/");
 
 			var invoice = new SalesInvoice {Description = "New Description"};
 			var line = new SalesInvoiceLine {Description = "InvoiceLine"};
-			invoice.SalesInvoiceLines = new List<SalesInvoiceLine> { line }; 
+			invoice.SalesInvoiceLines = new List<SalesInvoiceLine> { line };
 
-			var controller = (Controller<SalesInvoice>)instance.GetController<SalesInvoice>();
+			var controller = (Controller<SalesInvoice>)controllerList.GetController<SalesInvoice>();
 			var entityController = new EntityController(invoice, "ID", invoice.InvoiceID.ToString(), controllerMock, controller.GetEntityController);
 			Assert.IsTrue(controller.AddEntityToManagedEntitiesCollection(invoice));
 
@@ -68,16 +66,15 @@ namespace ExactOnline.Client.Sdk.UnitTests
 		[TestCategory("Unit Test")]
 		public void EntityController_Update_WithNoFieldsAltered_Succeeds()
 		{
-			ControllerSingleton.Clean();
 			var controllerMock = new ApiConnectionEntityControllerMock();
 			var connector = new ApiConnectorMock();
-			var instance = ControllerSingleton.GetInstance(connector, "https://start.exactonline.nl/api/v1/");
+			var controllerList = new ControllerList(connector, "https://start.exactonline.nl/api/v1/");
 
 			var invoice = new SalesInvoice {Description = "New Description"};
 			var line = new SalesInvoiceLine {Description = "Invoice Line"};
 			invoice.SalesInvoiceLines = new List<SalesInvoiceLine> { line }; 
 
-			var controller = (Controller<SalesInvoice>)instance.GetController<SalesInvoice>();
+			var controller = (Controller<SalesInvoice>)controllerList.GetController<SalesInvoice>();
 			var entityController = new EntityController(invoice, "ID", invoice.InvoiceID.ToString(), controllerMock, controller.GetEntityController);
 			var returnValue = controller.AddEntityToManagedEntitiesCollection(invoice);
 
@@ -93,16 +90,15 @@ namespace ExactOnline.Client.Sdk.UnitTests
 		[TestCategory("Unit Test")]
 		public void EntityController_Update_WithOnlyLinkedEntityFieldsAltered_Succeeds()
 		{
-			ControllerSingleton.Clean();
 			var controllerMock = new ApiConnectionEntityControllerMock();
 			var connector = new ApiConnectorMock();
-			ControllerSingleton instance = ControllerSingleton.GetInstance(connector, "https://start.exactonline.nl/api/v1/");
+			var controllerList = new ControllerList(connector, "https://start.exactonline.nl/api/v1/");
 
 			var invoice = new SalesInvoice {Description = "New Description"};
 			var line = new SalesInvoiceLine {Description = "InvoiceLine"};
 			invoice.SalesInvoiceLines = new List<SalesInvoiceLine> { line };
 
-			var controller = (Controller<SalesInvoice>)instance.GetController<SalesInvoice>();
+			var controller = (Controller<SalesInvoice>)controllerList.GetController<SalesInvoice>();
 			var ec = new EntityController(invoice, "ID", invoice.InvoiceID.ToString(), controllerMock, controller.GetEntityController);
 			Assert.IsTrue(controller.AddEntityToManagedEntitiesCollection(invoice));
 

--- a/test/ExactOnline.Client.Sdk.UserAcceptanceTests/UserLevel/RobustEndpoints.cs
+++ b/test/ExactOnline.Client.Sdk.UserAcceptanceTests/UserLevel/RobustEndpoints.cs
@@ -8,31 +8,45 @@ namespace ExactOnline.Client.Sdk.UserAcceptanceTests.UserLevel
 	[TestClass]
 	public class RobustEndpoints
 	{
+		private int _currentDivision;
+		private TestObjectsCreator _toc;
+
+		[TestInitialize]
+		public void InitializeSharedTestObjects()
+		{
+			_toc = new TestObjectsCreator();
+			_currentDivision = GetCurrentDivision(_toc);
+		}
+
+		private static int GetCurrentDivision(TestObjectsCreator toc)
+		{
+			var clientWithoutDivision = new ExactOnlineClient(toc.GetWebsite(), toc.GetOAuthAuthenticationToken);
+			return clientWithoutDivision.GetDivision();
+		}
+
 		[TestMethod]
 		[TestCategory("User Acceptance Tests")]
 		public void TestWithoutDivision()
 		{
-			var toc = new TestObjectsCreator();
-			var client = new ExactOnlineClient(toc.GetWebsite(), toc.GetOAuthAuthenticationToken);
-			var accounts = client.For<Account>().Select("Code").Get();
+			var client = new ExactOnlineClient(_toc.GetWebsite(), _toc.GetOAuthAuthenticationToken);
+			client.For<Account>().Select("Code").Get();
 		}
 
 		[TestMethod]
 		[TestCategory("User Acceptance Tests")]
 		public void TestWithDivision()
 		{
-			var toc = new TestObjectsCreator();
-			var client = new ExactOnlineClient(toc.GetWebsite(), 499156, toc.GetOAuthAuthenticationToken);
-			var accounts = client.For<Account>().Select("Code").Get();
+			var client = new ExactOnlineClient(_toc.GetWebsite(), _currentDivision, _toc.GetOAuthAuthenticationToken);
+			client.For<Account>().Select("Code").Get();
 		}
 
 		[TestMethod]
 		[TestCategory("User Acceptance Tests")]
 		public void TestWithSlash()
 		{
-			var toc = new TestObjectsCreator();
-			var client = new ExactOnlineClient(toc.GetWebsite(), 499156, toc.GetOAuthAuthenticationToken);
-			var accounts = client.For<Account>().Select("Code").Get();
+			var client = new ExactOnlineClient(_toc.GetWebsite(), _currentDivision, _toc.GetOAuthAuthenticationToken);
+			client.For<Account>().Select("Code").Get();
 		}
+
 	}
 }


### PR DESCRIPTION
Multiple instances of ExactOnlineClient using different connections are supported through this change.

* The ControllerSingleton is renamed to ControllerList and it's no longer a singleton. A few more changes in other files resulted from this.
* Added the **force_login=1** parameter to the authorization url when the user has to enter his credentials.
* Fixed 2 UserAcceptanceTests that had a hardcoded division number.
* Minor cleanups.
