### PR TITLE
Improved err handling in ApiController.GetResponse

### DIFF
--- a/src/ExactOnline.Client.Sdk/Exceptions/BadRequestException.cs
+++ b/src/ExactOnline.Client.Sdk/Exceptions/BadRequestException.cs
@@ -2,10 +2,15 @@
 
 namespace ExactOnline.Client.Sdk.Exceptions
 {
-	[Serializable]
-	public class BadRequestException : Exception // HTTP: 400
-	{
-		public BadRequestException() { }
-		public BadRequestException(string message) : base(message) { }
-	}
+    [Serializable]
+    public class BadRequestException : Exception // HTTP: 400
+    {
+        public BadRequestException() { }
+        public BadRequestException(string message) : base(message) { }
+        public BadRequestException(string message, Exception inner) : base(message, inner) { }
+        protected BadRequestException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
 }

--- a/src/ExactOnline.Client.Sdk/Exceptions/ForbiddenException.cs
+++ b/src/ExactOnline.Client.Sdk/Exceptions/ForbiddenException.cs
@@ -2,8 +2,15 @@
 
 namespace ExactOnline.Client.Sdk.Exceptions
 {
-	[Serializable]
-	public class ForbiddenException : Exception // HTTP: 403 
-	{
-	}
+    [Serializable]
+    public class ForbiddenException : Exception // HTTP: 403 
+    {
+        public ForbiddenException() { }
+        public ForbiddenException(string message) : base(message) { }
+        public ForbiddenException(string message, Exception inner) : base(message, inner) { }
+        protected ForbiddenException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
 }

--- a/src/ExactOnline.Client.Sdk/Exceptions/InternalServerErrorException.cs
+++ b/src/ExactOnline.Client.Sdk/Exceptions/InternalServerErrorException.cs
@@ -2,15 +2,15 @@
 
 namespace ExactOnline.Client.Sdk.Exceptions
 {
-	[Serializable]
-	public class InternalServerErrorException : Exception // HTTP 500
-	{
-		public InternalServerErrorException()
-		{
-		}
-
-		public InternalServerErrorException(string message) : base(message)
-		{
-		}
-	}
+    [Serializable]
+    public class InternalServerErrorException : Exception // HTTP 500
+    {
+        public InternalServerErrorException() { }
+        public InternalServerErrorException(string message) : base(message) { }
+        public InternalServerErrorException(string message, Exception inner) : base(message, inner) { }
+        protected InternalServerErrorException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
 }

--- a/src/ExactOnline.Client.Sdk/Exceptions/NotFoundException.cs
+++ b/src/ExactOnline.Client.Sdk/Exceptions/NotFoundException.cs
@@ -2,8 +2,15 @@
 
 namespace ExactOnline.Client.Sdk.Exceptions
 {
-	[Serializable]
-	public class NotFoundException : Exception // HTTP: 404
-	{
-	}
+    [Serializable]
+    public class NotFoundException : Exception // HTTP: 404
+    {
+        public NotFoundException() { }
+        public NotFoundException(string message) : base(message) { }
+        public NotFoundException(string message, Exception inner) : base(message, inner) { }
+        protected NotFoundException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
 }

--- a/src/ExactOnline.Client.Sdk/Exceptions/UnauthorizedException.cs
+++ b/src/ExactOnline.Client.Sdk/Exceptions/UnauthorizedException.cs
@@ -2,8 +2,15 @@
 
 namespace ExactOnline.Client.Sdk.Exceptions
 {
-	[Serializable]
-	public class UnauthorizedException : Exception // HTTP: 401
-	{
-	}
+    [Serializable]
+    public class UnauthorizedException : Exception // HTTP: 401
+    {
+        public UnauthorizedException() { }
+        public UnauthorizedException(string message) : base(message) { }
+        public UnauthorizedException(string message, Exception inner) : base(message, inner) { }
+        protected UnauthorizedException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context)
+            : base(info, context) { }
+    }
 }


### PR DESCRIPTION
-The GetResponse method swallowed any exceptions and returned an empty
string if anything else than the WebException was thrown, causing
valuable information to get lost.
-In case an WebException was thrown, more specific exceptions are
thrown, but those exceptions did not wrap the original exception causing
valuable information about the error to get lost.